### PR TITLE
Added support for chunked responses

### DIFF
--- a/src/reactor/http.c
+++ b/src/reactor/http.c
@@ -295,3 +295,36 @@ void http_write_response(stream_t *stream, string_t status, string_t date, strin
   else
     http_write_response_extended(stream, status, date, type, body, fields, fields_count);
 }
+
+inline __attribute__((always_inline, flatten))
+void http_write_chunk_response(stream_t *stream, data_t content)
+{
+  // Push the chunked data to the stream
+  char chunk_size[10];
+  sprintf(chunk_size, "%lx\r\n", data_size(content));
+  size_t size = strlen(chunk_size) + data_size(content) + 2;
+  void *p = stream_allocate(stream, size);
+
+  http_push_data(&p, string(chunk_size));
+  http_push_data(&p, content);
+  http_push_data(&p, string("\r\n"));
+
+}
+
+inline __attribute__((always_inline, flatten))
+void http_write_chunk_start_response(stream_t *stream)
+{
+    // Push End of Stream
+    const char *headers =   "HTTP/1.1 200 OK\r\n"
+                            "Content-Type: text/plain\r\n"
+                            "Cache-Control: no-cache\r\n"
+                            "Transfer-Encoding: chunked\r\n"
+                            "Connection: keep-alive\r\n"
+                            "Keep-Alive: timeout=5\r\n"
+                            "\r\n";
+
+    size_t size = strlen(headers);
+    void *p = stream_allocate(stream, size);
+
+    http_push_data(&p, string(headers));
+}

--- a/src/reactor/http.h
+++ b/src/reactor/http.h
@@ -35,5 +35,7 @@ http_field_t http_field_define(string_t, string_t);
 string_t     http_field_lookup(http_field_t *, size_t, string_t);
 int          http_read_request(stream_t *, string_t *, string_t *, data_t *, http_field_t *, size_t *);
 void         http_write_response(stream_t *, string_t, string_t, string_t, data_t, http_field_t *, size_t);
+void         http_write_chunk_response(stream_t *stream, data_t content);
+void         http_write_chunk_start_response(stream_t *stream);
 
 #endif /* REACTOR_HTTP_H_INCLUDED */

--- a/src/reactor/server.h
+++ b/src/reactor/server.h
@@ -44,4 +44,8 @@ void server_respond(server_session_t *, string_t, string_t, data_t, http_field_t
 void server_ok(server_session_t *, string_t, data_t, http_field_t *, size_t);
 void server_plain(server_session_t *, data_t, http_field_t *, size_t);
 
+void server_respond_chunk(server_session_t *session, string_t content);
+void server_respond_chunk_start(server_session_t *session);
+void server_respond_chunk_end(server_session_t *session);
+
 #endif /* REACTOR_SERVER_H_INCLUDED */


### PR DESCRIPTION
Adds support for Transfer-Encoding: chunked responses. 

Has been tested extensively in my own personal project.

If additional unit tests are needed, please provide guidance on what cases should be tested